### PR TITLE
Check Attributes on Login

### DIFF
--- a/src/main/java/com/atherys/rpg/api/stat/AttributeType.java
+++ b/src/main/java/com/atherys/rpg/api/stat/AttributeType.java
@@ -21,13 +21,18 @@ public class AttributeType implements CatalogType {
 
     private String description;
 
-    AttributeType(String id, String shortName, String name, String description, boolean upgradable, boolean hidden, TextColor color) {
+    private double defaultValue;
+
+    AttributeType(String id, String shortName, String name, String description, boolean upgradable, boolean hidden,
+                  TextColor color, Double defaultValue) {
         this.id = id;
         this.name = name;
         this.shortName = shortName;
         this.upgradable = upgradable;
+        this.hidden = hidden;
         this.description = description;
         this.color = color;
+        this.defaultValue = defaultValue;
     }
 
     @Override
@@ -58,6 +63,10 @@ public class AttributeType implements CatalogType {
 
     public String getDescription() {
         return description;
+    }
+
+    public double getDefaultValue() {
+        return defaultValue;
     }
 
     @Override

--- a/src/main/java/com/atherys/rpg/api/stat/AttributeType.java
+++ b/src/main/java/com/atherys/rpg/api/stat/AttributeType.java
@@ -7,24 +7,26 @@ import java.util.Objects;
 
 public class AttributeType implements CatalogType {
 
-    private String id;
+    private final String id;
 
-    private String name;
+    private final String name;
 
-    private String shortName;
+    private final String shortName;
 
-    private boolean upgradable;
+    private final boolean upgradable;
 
-    private boolean hidden;
+    private final boolean hidden;
 
-    private TextColor color;
+    private final TextColor color;
 
-    private String description;
+    private final String description;
 
-    private double defaultValue;
+    private final double defaultValue;
+
+    private final boolean resetOnLogin;
 
     AttributeType(String id, String shortName, String name, String description, boolean upgradable, boolean hidden,
-                  TextColor color, Double defaultValue) {
+                  TextColor color, Double defaultValue, boolean resetOnLogin) {
         this.id = id;
         this.name = name;
         this.shortName = shortName;
@@ -33,6 +35,7 @@ public class AttributeType implements CatalogType {
         this.description = description;
         this.color = color;
         this.defaultValue = defaultValue;
+        this.resetOnLogin = resetOnLogin;
     }
 
     @Override
@@ -67,6 +70,10 @@ public class AttributeType implements CatalogType {
 
     public double getDefaultValue() {
         return defaultValue;
+    }
+
+    public boolean isResetOnLogin() {
+        return resetOnLogin;
     }
 
     @Override

--- a/src/main/java/com/atherys/rpg/api/stat/AttributeTypeRegistry.java
+++ b/src/main/java/com/atherys/rpg/api/stat/AttributeTypeRegistry.java
@@ -1,18 +1,14 @@
 package com.atherys.rpg.api.stat;
 
 import com.atherys.rpg.config.stat.AttributesConfig;
-import org.checkerframework.checker.units.qual.A;
 import org.spongepowered.api.registry.CatalogRegistryModule;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 public final class AttributeTypeRegistry implements CatalogRegistryModule<AttributeType> {
 
-    private Map<String, AttributeType> attributeTypeMap = new HashMap<>();
+    private Map<String, AttributeType> attributeTypeMap = new LinkedHashMap<>();
 
     public AttributeTypeRegistry() {
         try {
@@ -26,7 +22,8 @@ public final class AttributeTypeRegistry implements CatalogRegistryModule<Attrib
                     conf.getDescription(),
                     conf.isUpgradable(),
                     conf.isHidden(),
-                    conf.getColor()
+                    conf.getColor(),
+                    conf.getDefaultValue()
             )).forEach(type -> attributeTypeMap.put(type.getId(), type));
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/com/atherys/rpg/api/stat/AttributeTypeRegistry.java
+++ b/src/main/java/com/atherys/rpg/api/stat/AttributeTypeRegistry.java
@@ -23,7 +23,8 @@ public final class AttributeTypeRegistry implements CatalogRegistryModule<Attrib
                     conf.isUpgradable(),
                     conf.isHidden(),
                     conf.getColor(),
-                    conf.getDefaultValue()
+                    conf.getDefaultValue(),
+                    conf.isResetOnLogin()
             )).forEach(type -> attributeTypeMap.put(type.getId(), type));
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/com/atherys/rpg/config/stat/AttributeTypeConfig.java
+++ b/src/main/java/com/atherys/rpg/config/stat/AttributeTypeConfig.java
@@ -32,10 +32,14 @@ public class AttributeTypeConfig {
     @Setting("default-value")
     private double defaultValue = 0.0d;
 
+    @Setting(value = "reset-on-login", comment = "Whether this attribute should reset on login")
+    private boolean resetOnLogin = false;
+
     public AttributeTypeConfig() {
     }
 
-    public AttributeTypeConfig(String id, String shortName, String name, String description, boolean upgradable, boolean hidden, TextColor color, double defaultValue) {
+    public AttributeTypeConfig(String id, String shortName, String name, String description, boolean upgradable,
+                               boolean hidden, TextColor color, double defaultValue, boolean resetOnLogin) {
         this.id = id;
         this.name = name;
         this.shortName = shortName;
@@ -44,6 +48,7 @@ public class AttributeTypeConfig {
         this.hidden = hidden;
         this.color = color;
         this.defaultValue = defaultValue;
+        this.resetOnLogin = resetOnLogin;
     }
 
     public String getId() {
@@ -108,5 +113,13 @@ public class AttributeTypeConfig {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public void setResetOnLogin(boolean resetOnLogin) {
+        this.resetOnLogin = resetOnLogin;
+    }
+
+    public boolean isResetOnLogin() {
+        return resetOnLogin;
     }
 }

--- a/src/main/java/com/atherys/rpg/config/stat/AttributesConfig.java
+++ b/src/main/java/com/atherys/rpg/config/stat/AttributesConfig.java
@@ -23,7 +23,8 @@ public class AttributesConfig extends PluginConfig {
                 true,
                 false,
                 TextColors.RED,
-                1.0d
+                1.0d,
+                false
         ));
         ATTRIBUTE_TYPES.add(new AttributeTypeConfig(
                 "atherys:constitution",
@@ -33,7 +34,8 @@ public class AttributesConfig extends PluginConfig {
                 true,
                 false,
                 TextColors.YELLOW,
-                1.0d
+                1.0d,
+                false
         ));
         ATTRIBUTE_TYPES.add(new AttributeTypeConfig(
                 "atherys:dexterity",
@@ -43,7 +45,8 @@ public class AttributesConfig extends PluginConfig {
                 true,
                 false,
                 TextColors.GREEN,
-                1.0d
+                1.0d,
+                false
         ));
         ATTRIBUTE_TYPES.add(new AttributeTypeConfig(
                 "atherys:intelligence",
@@ -53,7 +56,8 @@ public class AttributesConfig extends PluginConfig {
                 true,
                 false,
                 TextColors.BLUE,
-                1.0d
+                1.0d,
+                false
         ));
         ATTRIBUTE_TYPES.add(new AttributeTypeConfig(
                 "atherys:wisdom",
@@ -63,7 +67,8 @@ public class AttributesConfig extends PluginConfig {
                 true,
                 false,
                 TextColors.LIGHT_PURPLE,
-                1.0d
+                1.0d,
+                false
         ));
         ATTRIBUTE_TYPES.add(new AttributeTypeConfig(
                 "atherys:magical_resistance",
@@ -73,7 +78,8 @@ public class AttributesConfig extends PluginConfig {
                 false,
                 false,
                 TextColors.AQUA,
-                1.0d
+                0.0d,
+                true
         ));
         ATTRIBUTE_TYPES.add(new AttributeTypeConfig(
                 "atherys:physical_resistance",
@@ -83,7 +89,8 @@ public class AttributesConfig extends PluginConfig {
                 false,
                 false,
                 TextColors.GOLD,
-                1.0d
+                0.0d,
+                true
         ));
         ATTRIBUTE_TYPES.add(new AttributeTypeConfig(
                 "atherys:base_armor",
@@ -93,7 +100,8 @@ public class AttributesConfig extends PluginConfig {
                 false,
                 true,
                 TextColors.DARK_AQUA,
-                1.0d
+                0.0d,
+                true
         ));
         ATTRIBUTE_TYPES.add(new AttributeTypeConfig(
                 "atherys:base_damage",
@@ -103,7 +111,8 @@ public class AttributesConfig extends PluginConfig {
                 false,
                 true,
                 TextColors.DARK_RED,
-                1.0d
+                0.0d,
+                true
         ));
     }
 

--- a/src/main/java/com/atherys/rpg/facade/AttributeFacade.java
+++ b/src/main/java/com/atherys/rpg/facade/AttributeFacade.java
@@ -167,24 +167,16 @@ public class AttributeFacade {
         Map<AttributeType, Double> buffAttributes = pc.getBuffAttributes();
         Map<AttributeType, Double> itemAttributes = attributeService.getEquipmentAttributes(player);
 
-        attributesConfig.ATTRIBUTE_TYPES.forEach(config -> {
-            Optional<AttributeType> type = Sponge.getRegistry().getType(AttributeType.class, config.getId());
-
-            // if no such type could be found, something's gone terribly wrong.
-            // This means that there is a configured attribute type which is not present in the registry.
-            // Throw an exception, as this could be a serious problem
-            if (!type.isPresent()) {
-                throw new NoSuchElementException("Configured attribute type '" + config.getId() + "' could not be found in the game registry.");
-            }
+        Sponge.getRegistry().getAllOf(AttributeType.class).forEach( type -> {
 
             // if the attribute is hidden, there's no need to proceed.
-            if (type.get().isHidden()) {
+            if (type.isHidden()) {
                 return;
             }
 
-            double base = baseAttributes.get(type.get());
-            double buff = buffAttributes.getOrDefault(type.get(), 0.0d);
-            double item = itemAttributes.getOrDefault(type.get(), 0.0d);
+            double base = baseAttributes.get(type);
+            double buff = buffAttributes.getOrDefault(type, 0.0d);
+            double item = itemAttributes.getOrDefault(type, 0.0d);
 
             int total = (int) Math.round(base + buff + item);
 
@@ -195,14 +187,14 @@ public class AttributeFacade {
             );
 
             Text textTotal = Text.builder()
-                    .append(Text.of(config.getColor(), BOLD, total))
+                    .append(Text.of(type.getColor(), BOLD, total))
                     .onHover(TextActions.showText(hoverText))
                     .build();
 
             Text upgradeButton;
 
-            if (config.isUpgradable()) {
-                upgradeButton = getAddAttributeButton(pc, type.get(), base);
+            if (type.isUpgradable()) {
+                upgradeButton = getAddAttributeButton(pc, type, base);
             } else {
                 upgradeButton = Text.EMPTY;
             }
@@ -210,7 +202,7 @@ public class AttributeFacade {
             Text attribute = Text.builder()
                     .append(NEW_LINE)
                     .append(upgradeButton)
-                    .append(Text.of(TextActions.showText(getAttributeDescription(type.get())), config.getColor(), config.getName(), ": ", TextColors.RESET, textTotal))
+                    .append(Text.of(TextActions.showText(getAttributeDescription(type)), type.getColor(), type.getName(), ": ", TextColors.RESET, textTotal))
                     .build();
 
             attributeText.append(attribute);

--- a/src/main/java/com/atherys/rpg/facade/RPGCharacterFacade.java
+++ b/src/main/java/com/atherys/rpg/facade/RPGCharacterFacade.java
@@ -9,10 +9,7 @@ import com.atherys.rpg.character.PlayerCharacter;
 import com.atherys.rpg.command.exception.RPGCommandException;
 import com.atherys.rpg.config.AtherysRPGConfig;
 import com.atherys.rpg.data.DamageExpressionData;
-import com.atherys.rpg.service.DamageService;
-import com.atherys.rpg.service.ExpressionService;
-import com.atherys.rpg.service.HealingService;
-import com.atherys.rpg.service.RPGCharacterService;
+import com.atherys.rpg.service.*;
 import com.atherys.skills.AtherysSkills;
 import com.atherys.skills.api.event.ResourceEvent;
 import com.atherys.skills.api.resource.ResourceUser;
@@ -69,6 +66,9 @@ public class RPGCharacterFacade {
 
     @Inject
     private AttributeFacade attributeFacade;
+
+    @Inject
+    private AttributeService attributeService;
 
     @Inject
     private RPGSkillFacade skillFacade;
@@ -134,6 +134,16 @@ public class RPGCharacterFacade {
             characterService.resetCharacter(pc);
             characterService.addSkill(pc, skillGraphFacade.getSkillGraphRoot());
             rpgMsg.info(player, "The server's skill tree has changed. Your attributes and skill tree have been reset.");
+        }
+    }
+
+    public void checkAttributesDefaults(PlayerCharacter pc) {
+        Map<AttributeType, Double> attributes = attributeService.getBaseAttributes(pc);
+
+        for (AttributeType type : Sponge.getRegistry().getAllOf(AttributeType.class)) {
+            if (!attributes.containsKey(type) || type.isResetOnLogin() || attributes.get(type) < type.getDefaultValue()) {
+                characterService.setAttribute(pc, type, type.getDefaultValue());
+            }
         }
     }
 
@@ -385,6 +395,7 @@ public class RPGCharacterFacade {
         setPlayerHealth(player, fill);
         setPlayerResourceLimit(player, fill);
         checkTreeOnLogin(player);
+        checkAttributesDefaults(pc);
     }
 
     public void onPlayerRespawn(Player player) {

--- a/src/main/java/com/atherys/rpg/service/AttributeService.java
+++ b/src/main/java/com/atherys/rpg/service/AttributeService.java
@@ -37,17 +37,8 @@ public class AttributeService {
     public Map<AttributeType, Double> getDefaultAttributes() {
         Map<AttributeType, Double> defaultAttributes = new HashMap<>();
 
-        attributesConfig.ATTRIBUTE_TYPES.forEach(config -> {
-            Optional<AttributeType> type = Sponge.getRegistry().getType(AttributeType.class, config.getId());
-
-            // if no such type could be found, something's gone terribly wrong.
-            // This means that there is a configured attribute type which is not present in the registry.
-            // Throw an exception, as this could be a serious problem
-            if (!type.isPresent()) {
-                throw new NoSuchElementException("Configured attribute type '" + config.getId() + "' could not be found in the game registry.");
-            }
-
-            defaultAttributes.put(type.get(), config.getDefaultValue());
+        Sponge.getRegistry().getAllOf(AttributeType.class).forEach( type -> {
+            defaultAttributes.put(type, type.getDefaultValue());
         });
 
         return fillInAttributes(defaultAttributes);

--- a/src/main/java/com/atherys/rpg/service/RPGCharacterService.java
+++ b/src/main/java/com/atherys/rpg/service/RPGCharacterService.java
@@ -132,6 +132,12 @@ public class RPGCharacterService {
         Sponge.getEventManager().post(new ChangeAttributeEvent(pc));
     }
 
+    public void setAttribute(PlayerCharacter pc, AttributeType attributeType, double amount) {
+        pc.getBaseAttributes().put(attributeType, amount);
+        repository.saveOne(pc);
+        Sponge.getEventManager().post(new ChangeAttributeEvent(pc));
+    }
+
     public void removeAttribute(PlayerCharacter pc, AttributeType attributeType, double amount) {
         pc.getBaseAttributes().merge(attributeType, amount, (v1, v2) -> Math.abs(v1 - v2));
         repository.saveOne(pc);


### PR DESCRIPTION
When new Attributes are added or when default values are updated in the config, players do not receive the updated value.
Also added an option to force a value to reset to the base when a player logs in